### PR TITLE
Potential fix for code scanning alert no. 1: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/com/springsecurity/Oauth2/SecuritConfigForOauth.java
+++ b/src/main/java/com/springsecurity/Oauth2/SecuritConfigForOauth.java
@@ -29,7 +29,6 @@ public class SecuritConfigForOauth {
     public SecurityFilterChain securityFilterChain(HttpSecurity http, CustomOAuth2SuccessHandler successHandler) throws Exception {
         http.authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .csrf(csrf -> csrf.disable())
                 .oauth2Login(oauth -> oauth.successHandler(successHandler))
                 .addFilterBefore(new OauthValidationFilter(tokenValidatorUtil), UsernamePasswordAuthenticationFilter.class);
         return  http.build();


### PR DESCRIPTION
Potential fix for [https://github.com/rmishra96/SpringSecurity/security/code-scanning/1](https://github.com/rmishra96/SpringSecurity/security/code-scanning/1)

**General fix:**  
To address the CSRF vulnerability, CSRF protection should not be globally disabled. Instead, use the default CSRF protection provided by Spring Security. If there are endpoints which do need to have CSRF disabled (for example, REST endpoints intended solely for token-authenticated, non-browser clients), then explicitly permit those particular endpoints while keeping CSRF protection enabled for browser-accessible flows.

**Detailed steps for this code:**  
- In the `securityFilterChain` method, remove or comment out the `csrf(csrf -> csrf.disable())` line.
- By omitting `.csrf(...)` entirely, Spring Security will default to enabling CSRF protection for appropriate HTTP methods (e.g., POST, PUT, DELETE).
- If there's a need to *selectively* disable CSRF just for certain endpoints (such as a `/api/**` REST endpoint), use `.csrf(csrf -> csrf.ignoringRequestMatchers(...))`, but this is only necessary with strong justification.  
In this code snippet, simply removing the `csrf.disable()` invocation suffices.

**Region to change:**  
- File: src/main/java/com/springsecurity/Oauth2/SecuritConfigForOauth.java
- Method: `securityFilterChain`
- Line: Remove `.csrf(csrf -> csrf.disable())`

**Imports/Definitions:**  
- No new imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
